### PR TITLE
refactor: update package.json import method for compatibility with no…

### DIFF
--- a/utils/notify.js
+++ b/utils/notify.js
@@ -1,7 +1,11 @@
 import nodemailer from "nodemailer";
 import axios from "axios";
 import env from "./env.js";
-import pkg from "../package.json" assert { type: "json" };
+import { readFileSync } from "fs";
+
+const pkg = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8")
+);
 
 export class Notify {
   /**


### PR DESCRIPTION
Node22 版本以上不再支持 assert 进行导入断言，需要使用 with 
为了更好的兼容性，改成 fs.readFile 方式